### PR TITLE
fix(test): consume pCloud digest only once

### DIFF
--- a/lib/tests/http.rs
+++ b/lib/tests/http.rs
@@ -1,8 +1,5 @@
 #![cfg(feature = "protected")]
 
-use std::panic;
-
-use pcloud::builder::ClientBuilder;
 use pcloud::file::upload::MultiFileUpload;
 use pcloud::folder::ROOT;
 use pcloud::Credentials;
@@ -42,9 +39,6 @@ async fn complete() {
 
     let credentials = Credentials::username_password_digest(username, digest.value, password);
     let client = client.with_credentials(credentials);
-
-    // fetches the user informations
-    let _info = client.user_info().await.unwrap();
 
     let token = client.get_token().await.unwrap();
     let client = client.with_credentials(Credentials::authorization(token));


### PR DESCRIPTION
## Summary
- The `complete` integration test in `lib/tests/http.rs` started failing on `main` after #116. It panicked at `client.get_token().await.unwrap()` with a `Reqwest(Decode)` error because the JSON response no longer matched any `Response<Token>` variant.
- pCloud's auth digest is consumed by a single authenticated request. The test was calling `user_info()` and then `get_token()` against `userinfo` with the same digest, so the second call ran without valid credentials and the body the client received did not include the expected `auth` field.
- Drop the redundant `user_info()` call so the digest is spent exchanging credentials for an auth token; the existing `user_info()` call performed via the auth token still covers that endpoint.

## Test plan
- [ ] CI `Run all the tests` job (`cargo nextest run --features protected --retries 5`) is green.