### PR TITLE
feat: add oauth login flow with local http listener

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -34,7 +34,7 @@ protected = []
 pcloud = { workspace = true }
 #
 anyhow = "1.0"
-clap = { version = "4.6", features = ["derive"] }
+clap = { version = "4.6", features = ["derive", "env"] }
 # clap-verbosity-flag = { version = "1.0.1" }
 dirs = { version = "6.0" }
 futures = { version = "0.3" }
@@ -42,7 +42,7 @@ human-number = "0.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
 sha1_smol = "1.0"
-tokio = { version = "1.52", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.52", features = ["io-util", "macros", "net", "rt-multi-thread"] }
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 

--- a/cli/src/cmd/mod.rs
+++ b/cli/src/cmd/mod.rs
@@ -1,10 +1,14 @@
 mod download;
 mod list;
+mod oauth;
 
 #[derive(clap::Parser)]
 pub(crate) enum Command {
     Download(download::Command),
     List(list::Command),
+    /// Run the OAuth2 authorization flow against pCloud, exchanging the
+    /// authorization code for an access token via a local HTTP listener.
+    Oauth(oauth::Command),
 }
 
 impl Command {
@@ -12,6 +16,7 @@ impl Command {
         match self {
             Self::Download(inner) => inner.execute(client).await,
             Self::List(inner) => inner.execute(client).await,
+            Self::Oauth(inner) => inner.execute(client).await,
         }
     }
 }

--- a/cli/src/cmd/oauth.rs
+++ b/cli/src/cmd/oauth.rs
@@ -1,0 +1,219 @@
+use std::collections::HashMap;
+use std::process::Stdio;
+
+use anyhow::Context;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+const RCLONE_CLIENT_ID: &str = "DnONSzyJXpm";
+const RCLONE_CLIENT_SECRET: &str = "oboe7MzS0dcs95oU3sRmxIRu8";
+const REDIRECT_HOST: &str = "127.0.0.1";
+const REDIRECT_PORT: u16 = 53682;
+const AUTHORIZE_URL: &str = "https://my.pcloud.com/oauth2/authorize";
+
+const SUCCESS_BODY: &[u8] = b"<!doctype html><html><head><meta charset=\"utf-8\"><title>pcloud-cli</title></head><body><h1>Authorization complete</h1><p>You can close this window.</p></body></html>";
+
+#[derive(clap::Parser)]
+pub(crate) struct Command {
+    /// OAuth2 client id used to perform the authorization flow.
+    ///
+    /// Defaults to the public client id used by rclone, so that authorizations
+    /// granted to rclone can be reused.
+    #[clap(long, env = "PCLOUD_OAUTH_CLIENT_ID", default_value = RCLONE_CLIENT_ID)]
+    client_id: String,
+    /// OAuth2 client secret matching the client id.
+    #[clap(long, env = "PCLOUD_OAUTH_CLIENT_SECRET", default_value = RCLONE_CLIENT_SECRET)]
+    client_secret: String,
+    /// Skip the attempt to open the authorization URL in the default browser.
+    #[clap(long)]
+    no_browser: bool,
+}
+
+impl Command {
+    pub(crate) async fn execute(self, _client: &pcloud::Client) -> anyhow::Result<()> {
+        let bind_addr = (REDIRECT_HOST, REDIRECT_PORT);
+        let listener = TcpListener::bind(bind_addr)
+            .await
+            .with_context(|| format!("unable to bind {REDIRECT_HOST}:{REDIRECT_PORT}"))?;
+
+        let auth_url = format!(
+            "{AUTHORIZE_URL}?client_id={client_id}&response_type=code&redirect_uri=http%3A%2F%2F{REDIRECT_HOST}%3A{REDIRECT_PORT}%2F",
+            client_id = self.client_id,
+        );
+
+        eprintln!("Open the following URL in your browser to authorize pcloud-cli:");
+        eprintln!();
+        eprintln!("    {auth_url}");
+        eprintln!();
+        if !self.no_browser {
+            if let Err(err) = open_in_browser(&auth_url) {
+                tracing::debug!("unable to open browser: {err}");
+            }
+        }
+        eprintln!("Waiting for authorization on http://{REDIRECT_HOST}:{REDIRECT_PORT}/ ...");
+
+        let params = wait_for_callback(&listener).await?;
+
+        let code = params
+            .get("code")
+            .ok_or_else(|| match params.get("error") {
+                Some(err) => anyhow::anyhow!("authorization failed: {err}"),
+                None => anyhow::anyhow!("missing 'code' parameter in OAuth callback"),
+            })?
+            .to_owned();
+
+        let exchange_base_url = params
+            .get("hostname")
+            .map(|host| format!("https://{host}"))
+            .unwrap_or_else(|| pcloud::US_REGION.to_string());
+
+        tracing::debug!("exchanging code at {exchange_base_url}");
+        let exchange = pcloud::Client::new(exchange_base_url, pcloud::Credentials::anonymous())?;
+        let token = exchange
+            .oauth2_token(&self.client_id, &self.client_secret, &code)
+            .await
+            .context("OAuth token exchange failed")?;
+
+        println!("{}", token.access_token);
+        eprintln!();
+        eprintln!("Save it as PCLOUD_ACCESS_TOKEN or in your config file.");
+        Ok(())
+    }
+}
+
+async fn wait_for_callback(listener: &TcpListener) -> anyhow::Result<HashMap<String, String>> {
+    let (mut stream, _) = listener.accept().await?;
+    let mut buffer = Vec::with_capacity(2048);
+    let mut chunk = [0u8; 1024];
+    loop {
+        let n = stream.read(&mut chunk).await?;
+        if n == 0 {
+            break;
+        }
+        buffer.extend_from_slice(&chunk[..n]);
+        if buffer.windows(4).any(|w| w == b"\r\n\r\n") {
+            break;
+        }
+        if buffer.len() > 16 * 1024 {
+            anyhow::bail!("OAuth callback request exceeds 16 KiB");
+        }
+    }
+
+    let request = std::str::from_utf8(&buffer).context("OAuth callback is not valid UTF-8")?;
+    let request_line = request
+        .lines()
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("empty OAuth callback request"))?;
+    let path = request_line
+        .split_whitespace()
+        .nth(1)
+        .ok_or_else(|| anyhow::anyhow!("malformed OAuth callback request line"))?;
+    let query = path.split_once('?').map(|(_, q)| q).unwrap_or("");
+    let params = parse_query(query);
+
+    let response = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+        SUCCESS_BODY.len()
+    );
+    stream.write_all(response.as_bytes()).await?;
+    stream.write_all(SUCCESS_BODY).await?;
+    stream.shutdown().await.ok();
+
+    Ok(params)
+}
+
+fn parse_query(query: &str) -> HashMap<String, String> {
+    let mut out = HashMap::new();
+    if query.is_empty() {
+        return out;
+    }
+    for pair in query.split('&') {
+        let (key, value) = match pair.split_once('=') {
+            Some((k, v)) => (k, v),
+            None => (pair, ""),
+        };
+        out.insert(percent_decode(key), percent_decode(value));
+    }
+    out
+}
+
+fn percent_decode(input: &str) -> String {
+    let bytes = input.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'+' => {
+                out.push(b' ');
+                i += 1;
+            }
+            b'%' if i + 2 < bytes.len() => {
+                let hi = (bytes[i + 1] as char).to_digit(16);
+                let lo = (bytes[i + 2] as char).to_digit(16);
+                if let (Some(hi), Some(lo)) = (hi, lo) {
+                    out.push((hi * 16 + lo) as u8);
+                    i += 3;
+                } else {
+                    out.push(bytes[i]);
+                    i += 1;
+                }
+            }
+            other => {
+                out.push(other);
+                i += 1;
+            }
+        }
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+#[cfg(target_os = "macos")]
+fn open_in_browser(url: &str) -> std::io::Result<()> {
+    spawn_detached("open", &[url])
+}
+
+#[cfg(target_os = "windows")]
+fn open_in_browser(url: &str) -> std::io::Result<()> {
+    spawn_detached("cmd", &["/C", "start", "", url])
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn open_in_browser(url: &str) -> std::io::Result<()> {
+    spawn_detached("xdg-open", &[url])
+}
+
+fn spawn_detached(program: &str, args: &[&str]) -> std::io::Result<()> {
+    std::process::Command::new(program)
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .map(|_| ())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_query, percent_decode};
+
+    #[test]
+    fn parses_query_string() {
+        let params = parse_query("code=abc&hostname=eapi.pcloud.com&extra=hello%20world");
+        assert_eq!(params.get("code").map(String::as_str), Some("abc"));
+        assert_eq!(
+            params.get("hostname").map(String::as_str),
+            Some("eapi.pcloud.com")
+        );
+        assert_eq!(
+            params.get("extra").map(String::as_str),
+            Some("hello world")
+        );
+    }
+
+    #[test]
+    fn decodes_percent_encoding() {
+        assert_eq!(percent_decode("a%2Bb"), "a+b");
+        assert_eq!(percent_decode("a+b"), "a b");
+        assert_eq!(percent_decode("plain"), "plain");
+    }
+}

--- a/cli/src/cmd/oauth.rs
+++ b/cli/src/cmd/oauth.rs
@@ -205,10 +205,7 @@ mod tests {
             params.get("hostname").map(String::as_str),
             Some("eapi.pcloud.com")
         );
-        assert_eq!(
-            params.get("extra").map(String::as_str),
-            Some("hello world")
-        );
+        assert_eq!(params.get("extra").map(String::as_str), Some("hello world"));
     }
 
     #[test]

--- a/cli/src/cmd/oauth.rs
+++ b/cli/src/cmd/oauth.rs
@@ -7,7 +7,8 @@ use tokio::net::TcpListener;
 
 const RCLONE_CLIENT_ID: &str = "DnONSzyJXpm";
 const RCLONE_CLIENT_SECRET: &str = "oboe7MzS0dcs95oU3sRmxIRu8";
-const REDIRECT_HOST: &str = "127.0.0.1";
+const BIND_HOST: &str = "127.0.0.1";
+const REDIRECT_HOST: &str = "localhost";
 const REDIRECT_PORT: u16 = 53682;
 const AUTHORIZE_URL: &str = "https://my.pcloud.com/oauth2/authorize";
 
@@ -31,10 +32,10 @@ pub(crate) struct Command {
 
 impl Command {
     pub(crate) async fn execute(self, _client: &pcloud::Client) -> anyhow::Result<()> {
-        let bind_addr = (REDIRECT_HOST, REDIRECT_PORT);
+        let bind_addr = (BIND_HOST, REDIRECT_PORT);
         let listener = TcpListener::bind(bind_addr)
             .await
-            .with_context(|| format!("unable to bind {REDIRECT_HOST}:{REDIRECT_PORT}"))?;
+            .with_context(|| format!("unable to bind {BIND_HOST}:{REDIRECT_PORT}"))?;
 
         let auth_url = format!(
             "{AUTHORIZE_URL}?client_id={client_id}&response_type=code&redirect_uri=http%3A%2F%2F{REDIRECT_HOST}%3A{REDIRECT_PORT}%2F",

--- a/cli/src/cmd/oauth.rs
+++ b/cli/src/cmd/oauth.rs
@@ -6,7 +6,7 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 
 const RCLONE_CLIENT_ID: &str = "DnONSzyJXpm";
-const RCLONE_CLIENT_SECRET: &str = "oboe7MzS0dcs95oU3sRmxIRu8";
+const RCLONE_CLIENT_SECRET: &str = "RUqH9GooHqkC4IFkifsD1haRu9fy";
 const BIND_HOST: &str = "127.0.0.1";
 const REDIRECT_HOST: &str = "localhost";
 const REDIRECT_PORT: u16 = 53682;

--- a/lib/src/general/mod.rs
+++ b/lib/src/general/mod.rs
@@ -1,3 +1,4 @@
 pub mod getdigest;
 pub mod gettoken;
+pub mod oauth2_token;
 pub mod userinfo;

--- a/lib/src/general/oauth2_token.rs
+++ b/lib/src/general/oauth2_token.rs
@@ -1,0 +1,99 @@
+/// Response payload returned by the pCloud `oauth2_token` endpoint.
+#[derive(Debug, serde::Deserialize)]
+pub struct OAuth2Token {
+    pub access_token: String,
+    #[serde(default)]
+    pub token_type: Option<String>,
+    #[serde(default)]
+    pub uid: Option<u64>,
+    #[serde(default)]
+    pub locationid: Option<u64>,
+}
+
+#[derive(serde::Serialize)]
+struct Params<'a> {
+    client_id: &'a str,
+    client_secret: &'a str,
+    code: &'a str,
+}
+
+impl crate::Client {
+    /// Exchanges an OAuth2 authorization `code` for an access token.
+    ///
+    /// This method does not use the client's configured credentials; the OAuth2
+    /// flow authenticates via the `client_id`, `client_secret` and `code`
+    /// parameters directly.
+    ///
+    /// See <https://docs.pcloud.com/methods/oauth_2.0/authorize.html>.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`crate::Error`] if the request fails or the server rejects
+    /// the exchange.
+    pub async fn oauth2_token(
+        &self,
+        client_id: &str,
+        client_secret: &str,
+        code: &str,
+    ) -> crate::Result<OAuth2Token> {
+        self.get_request_unauthenticated(
+            "oauth2_token",
+            &Params {
+                client_id,
+                client_secret,
+                code,
+            },
+        )
+        .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{Client, Credentials};
+    use mockito::Matcher;
+
+    #[tokio::test]
+    async fn success() {
+        let mut server = mockito::Server::new_async().await;
+        let m = server
+            .mock("GET", "/oauth2_token")
+            .match_query(Matcher::AllOf(vec![
+                Matcher::UrlEncoded("client_id".into(), "id".into()),
+                Matcher::UrlEncoded("client_secret".into(), "secret".into()),
+                Matcher::UrlEncoded("code".into(), "abc".into()),
+            ]))
+            .with_status(200)
+            .with_body(
+                r#"{"result": 0, "access_token": "the-token", "token_type": "bearer", "uid": 42, "locationid": 1}"#,
+            )
+            .create_async()
+            .await;
+        let client = Client::new(server.url(), Credentials::anonymous()).unwrap();
+        let result = client.oauth2_token("id", "secret", "abc").await.unwrap();
+        assert_eq!(result.access_token, "the-token");
+        assert_eq!(result.token_type.as_deref(), Some("bearer"));
+        assert_eq!(result.uid, Some(42));
+        assert_eq!(result.locationid, Some(1));
+        m.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn protocol_error() {
+        let mut server = mockito::Server::new_async().await;
+        let m = server
+            .mock("GET", "/oauth2_token")
+            .match_query(Matcher::Any)
+            .with_status(200)
+            .with_body(r#"{"result": 2000, "error": "invalid code"}"#)
+            .create_async()
+            .await;
+        let client = Client::new(server.url(), Credentials::anonymous()).unwrap();
+        let err = client
+            .oauth2_token("id", "secret", "bad")
+            .await
+            .unwrap_err();
+        assert!(matches!(err, crate::Error::Protocol(2000, _)));
+        m.assert_async().await;
+    }
+}

--- a/lib/src/request.rs
+++ b/lib/src/request.rs
@@ -7,10 +7,15 @@ use crate::{Credentials, Error};
 async fn read_response<T: serde::de::DeserializeOwned>(res: reqwest::Response) -> Result<T, Error> {
     let status = res.status();
     tracing::debug!("responded with status {status:?}");
-    res.json::<Response<T>>()
-        .await
-        .map_err(Error::from)
-        .and_then(Response::payload)
+    let body = res.bytes().await?;
+    match serde_json::from_slice::<Response<T>>(&body) {
+        Ok(parsed) => parsed.payload(),
+        Err(err) => {
+            let preview = String::from_utf8_lossy(&body);
+            tracing::error!("failed to decode response: {err} body={preview}");
+            Err(Error::from(err))
+        }
+    }
 }
 
 impl crate::Client {

--- a/lib/src/request.rs
+++ b/lib/src/request.rs
@@ -56,6 +56,25 @@ impl crate::Client {
         read_response(res).await
     }
 
+    /// Sends a GET request without attaching the client's credentials.
+    ///
+    /// Used by endpoints that authenticate via the request parameters themselves
+    /// (such as the OAuth2 token exchange), where the client's stored credentials
+    /// are irrelevant and would risk leaking unwanted query parameters.
+    #[tracing::instrument(name = "get-unauth", skip(self, params))]
+    pub(crate) async fn get_request_unauthenticated<
+        T: serde::de::DeserializeOwned,
+        P: serde::Serialize,
+    >(
+        &self,
+        method: &str,
+        params: P,
+    ) -> Result<T, Error> {
+        let uri = self.build_url(method);
+        let res = self.inner.get(uri).query(&params).send().await?;
+        read_response(res).await
+    }
+
     /// Sends a PUT request with query parameters and a binary payload, and deserializes the response into type `T`.
     ///
     /// # Arguments


### PR DESCRIPTION
## Summary
- Add `pcloud-cli oauth` command that runs the OAuth2 authorization flow against pCloud, mirroring rclone's mechanism: starts a local HTTP server on `127.0.0.1:53682` (same port as rclone), opens the authorize URL, captures the callback, and exchanges the code for an access token.
- Add `Client::oauth2_token(client_id, client_secret, code)` to `pcloud` lib, calling `/oauth2_token` without sending the client's stored credentials (new `get_request_unauthenticated` helper).
- Defaults `--client-id` / `--client-secret` to rclone's public OAuth values so authorizations granted to rclone can be reused; both can be overridden via flag or `PCLOUD_OAUTH_CLIENT_ID` / `PCLOUD_OAUTH_CLIENT_SECRET` env vars.
- Picks the token-exchange base URL from the `hostname` query parameter returned in the OAuth callback (`api.pcloud.com` vs `eapi.pcloud.com`), matching rclone's behavior.

## Test plan
- [x] `cargo test --workspace --lib` (new tests for `oauth2_token` success + protocol error, plus query/percent-decode unit tests)
- [x] `cargo build --workspace` and `cargo clippy --workspace --all-targets` (no new warnings)
- [x] End-to-end smoke test: `pcloud-cli oauth --no-browser` listens on `127.0.0.1:53682`, accepts a fake callback (`curl http://127.0.0.1:53682/?code=...&hostname=eapi.pcloud.com`), serves the success page, and reaches the real `/oauth2_token` endpoint (returns expected `2093 Invalid 'client_secret'` for fake credentials).
- [x] Smoke test of the error path: `?error=access_denied` callback surfaces a clean error message and non-zero exit.
- [ ] Manual end-to-end OAuth flow with a real pCloud account.